### PR TITLE
Fixes broken equation refrence

### DIFF
--- a/elsarticle-template-5-harv.tex
+++ b/elsarticle-template-5-harv.tex
@@ -351,7 +351,7 @@
         A rolling-resistance coefficient ($C_{rr}$) of 0.04 was chosen based on values found in an automotive handbook \citep{RobertBoschGmbH2002}.
         It represents the case of a pneumatic tyre on medium-hard soil.
         Other variables used are: a vehicle mass ($m$) of \SI{1900}{\kilo\gram}, slope angle ($\alpha$) of \SI{20}{\degree}, velocity change ($\Delta t$) of \SI{2.78}{\metre\per\second} (\SI{10}{\kilo\meter\per\hour}), and an acceleration time ($t$) of \SI{6}{\second}.
-        Putting these values into Equations \ref{eqn_f_rolling}--\ref{eqn_f_accel} gives a total force requirement of \SI{7.99}{\kilo\newton}.
+        Putting these values into Equations \ref{eqn_f_roll}--\ref{eqn_f_accel} gives a total force requirement of \SI{7.99}{\kilo\newton}.
         On a per-wheel basis this is \SI{2.0}{\kilo\newton}, or \SI{729}{\newton\meter} when taking the wheel radius ($r$) of \SI{0.365}{\meter} into account.
         Required traction power ($P$) is then calculated as follows:
         \begin{align}


### PR DESCRIPTION
On your last lot of updates you messed up an equation reference. I didn't spot it when I reviewed it but saw the compiler warning just now. Fixed.